### PR TITLE
Add support for returning the result of each job

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -12,7 +12,7 @@ This package provides a single function :func:`parq.run`, which runs jobs using 
 
 .. warning::
 
-   If you use :func:`parq.run` to run many jobs that each return a very large data structure, you should consider saving the results of each job to an external file, rather than passing ``results=True``.
+   If you use :func:`parq.run` to run jobs that return very large data structures, you should consider saving the results of each job to an external file, rather than passing ``results=True``.
 
 .. autofunction:: parq.run
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -3,6 +3,17 @@ API documentation
 
 .. module:: parq
 
+This package provides a single function :func:`parq.run`, which runs jobs using multiple Python processes and returns a :class:`parq.Result` value when all jobs have completed.
+
+.. note::
+
+   By default, **the return value of each job is ignored**.
+   To obtain the return value of each job, pass ``results=True`` to :func:`parq.run`.
+
+.. warning::
+
+   If you use :func:`parq.run` to run many jobs that each return a very large data structure, you should consider saving the results of each job to an external file, rather than passing ``results=True``.
+
 .. autofunction:: parq.run
 
 .. autoclass:: parq.Result

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,6 +30,31 @@ This package provides a single function :func:`parq.run`, which runs jobs using 
    >>> success = parq.run(my_job, job_inputs, n_proc=4)
    >>> assert success
 
+Job return values
+-----------------
+
+By default, **the return value of each job is ignored**.
+You can instruct :func:`parq.run` to record the return value of each job by passing ``results=True``.
+The ``job_results`` field will then contain a dictionary that maps job numbers (0, 1, 2, ...) to return values.
+
+.. code-block:: python
+
+   >>> import parq
+   >>> # Define a job that doubles its input argument.
+   >>> def double_input(x):
+   ...     return 2 * x
+   ...
+   >>> # Define the input argument for each job.
+   >>> job_inputs = [(i,) for i in range(10)]
+   >>> # Run these 10 jobs using 4 processes.
+   >>> result = parq.run(double_input, job_inputs, n_proc=4, results=True)
+   >>> # Check that we obtained the expected results.
+   >>> assert result.job_results == {i: 2 * i for i in range(10)}
+
+.. warning::
+
+   If you use :func:`parq.run` to run jobs that return very large data structures, you should consider saving the results of each job to an external file, rather than passing ``results=True``.
+
 Installation
 ------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,8 @@ The code is distributed under the terms of the BSD 3-Clause license (see
 A simple example
 ----------------
 
+This package provides a single function :func:`parq.run`, which runs jobs using multiple Python processes and returns a :class:`parq.Result` value when all jobs have completed.
+
 .. code-block:: python
 
    >>> import parq

--- a/src/parq/__init__.py
+++ b/src/parq/__init__.py
@@ -156,7 +156,7 @@ def _worker(config):
         except Exception:
             logger.debug('Worker caught an exception')
             if config.trace:
-                logger.info(traceback.format_exc())
+                logger.warning(traceback.format_exc())
             status_ok = False
             if config.fail_early:
                 logger.debug('Will stop workers early')

--- a/src/parq/__init__.py
+++ b/src/parq/__init__.py
@@ -313,9 +313,9 @@ def run(
             # Spawn no more processes than there are jobs
             n_proc = n_jobs
         logger.info('Spawning {} workers for {} jobs'.format(n_proc, n_jobs))
-        for _ in range(n_proc):
+        for i in range(n_proc):
             proc = multiprocessing.Process(
-                target=_worker, args=[worker_config]
+                target=_worker, args=[worker_config], name=f'parq-{i + 1}'
             )
             workers.append(proc)
             proc.start()

--- a/src/parq/__init__.py
+++ b/src/parq/__init__.py
@@ -165,11 +165,12 @@ def _worker(config):
                     config.stop_workers.value = True
                 break
 
-    logger.info(f'Worker exiting, {counter} jobs, success = {status_ok}')
+    logger.debug('Worker sending sentinel')
     if config.collect_results:
         config.out_queue.put((-1, None), block=True)
     else:
         config.out_queue.put(-1, block=True)
+    logger.info(f'Worker exiting, {counter} jobs, success = {status_ok}')
     if not status_ok:
         sys.exit(1)
 

--- a/tests/test_kill_worker.py
+++ b/tests/test_kill_worker.py
@@ -1,0 +1,67 @@
+"""Test cases that kill worker processes."""
+
+import os
+import parq
+import time
+
+
+def test_kill_worker_single():
+    """
+    Kill a single worker process.
+    """
+
+    def func(kill):
+        # NOTE: make each job take a non-zero amount of time to complete.
+        time.sleep(0.01)
+        if kill:
+            os.kill(os.getpid(), 9)
+
+    n_proc = 2
+    n_jobs = 16
+    timeout = 1
+    kill_at = 7
+
+    values = [(i == kill_at,) for i in range(n_jobs)]
+
+    result = parq.run(
+        func,
+        values,
+        n_proc=n_proc,
+        timeout=timeout,
+    )
+
+    assert not result.success
+    assert len(result.successful_jobs) == n_jobs - 1
+    assert len(result.unsuccessful_jobs) == 1
+    assert result.failed_worker_count == 1
+
+
+def test_kill_worker_all():
+    """
+    Kill all worker processes.
+    """
+
+    def func(kill):
+        # NOTE: make each job take a non-zero amount of time to complete.
+        time.sleep(0.01)
+        if kill:
+            os.kill(os.getpid(), 9)
+
+    n_proc = 2
+    n_jobs = 16
+    timeout = 1
+    kill_from = 7
+
+    values = [(i >= kill_from,) for i in range(n_jobs)]
+
+    result = parq.run(
+        func,
+        values,
+        n_proc=n_proc,
+        timeout=timeout,
+    )
+
+    assert not result.success
+    assert len(result.successful_jobs) <= kill_from
+    assert len(result.unsuccessful_jobs) >= (n_jobs - kill_from)
+    assert result.failed_worker_count == n_proc

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,48 @@
+"""Test cases for retrieving job results."""
+
+import parq
+
+
+def test_results_simple():
+    """
+    Ensure that we can retrieve the results of a small number of jobs, where
+    each job returns a scalar value.
+    """
+    job_count = 10
+    n_proc = 4
+
+    values = [(i,) for i in range(job_count)]
+
+    def func(x):
+        return 2 * x
+
+    result = parq.run(func, values, n_proc, results=True)
+    assert result
+
+    # Check the result of each job.
+    for i in range(job_count):
+        assert result.job_results[i] == 2 * i
+
+
+def test_results_large():
+    """
+    Ensure that we can retrieve the results of many jobs, where each job
+    returns a large data structure.
+    """
+
+    job_count = 200
+    result_length = 1_000_000
+    n_proc = 2
+
+    values = [(i,) for i in range(job_count)]
+
+    def func(x):
+        return [x for _ in range(result_length)]
+
+    result = parq.run(func, values, n_proc, results=True)
+    assert result
+
+    # Check the result of each job.
+    for i in range(job_count):
+        output = result.job_results[i]
+        assert len(output) == result_length


### PR DESCRIPTION
By passing `results=True` to `parq.run()`, we now collect the return value of each job and return these values to the caller. See `tests/test_results.py` for examples.

This can be convenient for jobs that return small data structures. However, it should probably not be used when running many jobs that each return a very large data structure; in such cases, alternatives such as saving outputs to disk should probably be used.